### PR TITLE
feat: update to purs 0.14

### DIFF
--- a/src/Dodo/Ansi.purs
+++ b/src/Dodo/Ansi.purs
@@ -145,7 +145,7 @@ ansiGraphics = Printer
   getCurrentGraphics :: List Ansi.GraphicsParam -> List Ansi.GraphicsParam
   getCurrentGraphics =
     List.takeWhile (_ /= Ansi.Reset)
-      >>> List.nubBy graphicsConflict
+      >>> List.nubByEq graphicsConflict
       >>> List.reverse
 
   getPendingGraphics :: List Ansi.GraphicsParam -> Maybe (NonEmptyList Ansi.GraphicsParam)


### PR DESCRIPTION
```
in module Dodo.Ansi
at .spago/dodo-printer/master/src/Dodo/Ansi.purs:148:22 - 148:38 (line 148, column 22 - line 148, column 38)

  Could not match type

    Boolean

  with type

    Ordering

while checking that type GraphicsParam -> GraphicsParam -> Boolean
  is at least as general as type t0 -> t0 -> Ordering
while checking that expression graphicsConflict
  has type t0 -> t0 -> Ordering
in value declaration ansiGraphics

where t0 is an unknown type

See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,
or to contribute content related to this error.
```