### PR TITLE
Update to PureScript 0.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           purescript: "0.15.0"
           purs-tidy: "0.8.0"
-          spago: "0.20.8"
+          spago: "0.20.9"
 
       - name: Build source
         run: spago build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: purescript-contrib/setup-purescript@main
+        with:
+          purescript: "0.15.0"
+          purs-tidy: "0.8.0"
+          spago: "0.20.8"
+
+      - name: Build source
+        run: spago build
+
+      - name: Run tests
+        run: spago test --no-install
+
+      - name: Verify formatting
+        run: purs-tidy check src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
         run: spago test --no-install
 
       - name: Verify formatting
-        run: purs-tidy check src
+        run: purs-tidy check src test

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "ide",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,8 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.3-20210811/packages.dhall sha256:a2de7ef2f2e753733eddfa90573a82da0c7c61d46fa87d015b7f15ef8a6e97d5
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.0-20220509/packages.dhall
+        sha256:d4c1a03606efdbb7bb7745a9d3aa908cb1ba5611921373659a4c7bf1c41c106c
 
-let overrides = {=}
-
-let additions = {=}
-
-in  upstream // overrides // additions
+in  upstream

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,8 +1,6 @@
-{-
-Welcome to a Spago project!
-You can edit this file as you like.
--}
 { name = "dodo-printer"
+, license = "MIT"
+, repository = "https://github.com/natefaubion/purescript-dodo-printer.git"
 , dependencies =
   [ "aff"
   , "ansi"
@@ -29,7 +27,6 @@ You can edit this file as you like.
   , "partial"
   , "posix-types"
   , "prelude"
-  , "psci-support"
   , "safe-coerce"
   , "strings"
   , "tuples"

--- a/src/Dodo.purs
+++ b/src/Dodo.purs
@@ -51,7 +51,7 @@ import Data.String.Regex as Regex
 import Data.String.Regex.Flags (global)
 import Data.String.Regex.Unsafe (unsafeRegex)
 import Data.Tuple (Tuple(..))
-import Dodo.Internal (Doc(..), Position, LocalOptions, bothNotEmpty, isEmpty, notEmpty)
+import Dodo.Internal (Doc(..), LocalOptions, Position, bothNotEmpty, isEmpty, notEmpty)
 import Dodo.Internal (Doc, Position, bothNotEmpty, isEmpty, notEmpty) as Exports
 import Dodo.Internal.Buffer (Buffer)
 import Dodo.Internal.Buffer as Buffer
@@ -472,7 +472,7 @@ print (Printer printer) opts = flip go initState <<< pure <<< Doc
               , ribbonRatio: state.options.ribbonRatio
               }
             Tuple localOptions doc1 = k prevOptions
-          go (Doc doc1 : LeaveLocal prevOptions: stk) $ storeOptions state.position.indent localOptions state
+          go (Doc doc1 : LeaveLocal prevOptions : stk) $ storeOptions state.position.indent localOptions state
         Empty ->
           go stk state
       LeaveFlexGroup doc1 doc2 -> case state.flexGroup of

--- a/src/Dodo/Ansi.purs
+++ b/src/Dodo/Ansi.purs
@@ -9,7 +9,7 @@ module Dodo.Ansi
 
 import Prelude
 
-import Ansi.Codes (GraphicsParam, Color(..)) as Exports
+import Ansi.Codes (Color(..), GraphicsParam) as Exports
 import Ansi.Codes as Ansi
 import Data.List (List)
 import Data.List as List

--- a/test/Snapshot.purs
+++ b/test/Snapshot.purs
@@ -2,7 +2,7 @@ module Test.Snapshot where
 
 import Prelude
 
-import Control.MonadZero (guard)
+import Control.Alternative (guard)
 import Control.Parallel (parTraverse)
 import Data.Array (mapMaybe)
 import Data.Array as Array
@@ -72,7 +72,7 @@ snapshotMainOutput directory accept mbPattern = do
 
   runSnapshot :: String -> Aff SnapshotTest
   runSnapshot name = flip catchError (makeErrorResult name) do
-    result <- exec $ "node -e 'require(\"./output/" <> name <> "/index.js\").main()'"
+    result <- exec $ "node --input-type=module -e 'import { main } from \"./output/" <> name <> "/index.js\";main()'"
     case result of
       { error: Just err } ->
         throwError err

--- a/test/snapshots/DodoBox.purs
+++ b/test/snapshots/DodoBox.purs
@@ -72,7 +72,7 @@ table { headers, rows } =
   rowSep =
     horizontal
       [ joint
-      , horizontal $ Array.intersperse joint $  map
+      , horizontal $ Array.intersperse joint $ map
           ( \width ->
               fill (Dodo.text "-")
                 { width: width + 2

--- a/test/snapshots/DodoExampleJson.purs
+++ b/test/snapshots/DodoExampleJson.purs
@@ -40,18 +40,18 @@ infix 0 Tuple as :
 exampleJson :: Json
 exampleJson =
   JObject
-    [ "bool": JBool true
-    , "string": JString "bar"
-    , "number": JNumber 1234.0
-    , "array": JArray
+    [ "bool" : JBool true
+    , "string" : JString "bar"
+    , "number" : JNumber 1234.0
+    , "array" : JArray
         [ JNull
         , JString "two"
-        , JArray [ JString "three"]
+        , JArray [ JString "three" ]
         ]
-    , "object": JObject
+    , "object" : JObject
         []
-    , "wideObject": JObject
-        [ "key": JString "1111111111111111111111111111111111111111"
+    , "wideObject" : JObject
+        [ "key" : JString "1111111111111111111111111111111111111111"
         ]
     ]
 

--- a/test/snapshots/DodoFlexSelectHanging.purs
+++ b/test/snapshots/DodoFlexSelectHanging.purs
@@ -35,10 +35,11 @@ joinArgs args last = fst $ foldr go start args
   start = case last of
     Hang a b ->
       Tuple
-        (flexSelect
-          (spaceBreak <> a)
-          (flexGroup (spaceBreak <> b))
-          (flexGroup (spaceBreak <> indent b)))
+        ( flexSelect
+            (spaceBreak <> a)
+            (flexGroup (spaceBreak <> b))
+            (flexGroup (spaceBreak <> indent b))
+        )
         (break <> a <> flexGroup (spaceBreak <> indent b))
     NoHang a ->
       Tuple
@@ -53,10 +54,11 @@ joinArgs args last = fst $ foldr go start args
         Hang a b ->
           a <> flexGroup (spaceBreak <> indent b)
     Tuple
-      (flexSelect
-        (spaceBreak <> doc)
-        (fst next)
-        (snd next))
+      ( flexSelect
+          (spaceBreak <> doc)
+          (fst next)
+          (snd next)
+      )
       (break <> doc <> snd next)
 
 test :: forall a. Doc a


### PR DESCRIPTION
Updates dependencies for the project to PureScript 0.15. Since Bower users aren't supported by this library and there are no code changes, it's unclear what version this should be released as.

I also updated two things:

- I added CI so the tests are exercised on pull requests and pushes to master
- I added the purs-tidy formatter as well as a CI step to check formatting