### PR TITLE
Correct default for jsSquares

### DIFF
--- a/src/Dodo/Common.purs
+++ b/src/Dodo/Common.purs
@@ -41,7 +41,7 @@ jsCurlies = flexGroup <<< encloseEmptyAlt open close (text "{}") <<< indent
   close = flexAlt (text "}") (break <> text "}")
 
 jsSquares :: forall a. Doc a -> Doc a
-jsSquares = flexGroup <<< encloseEmptyAlt open close (text "{}") <<< indent
+jsSquares = flexGroup <<< encloseEmptyAlt open close (text "[]") <<< indent
   where
   open = flexAlt (text "[") (text "[" <> break)
   close = flexAlt (text "]") (break <> text "]")


### PR DESCRIPTION
The default case for an empty document surrounded in squares was printing `{}`